### PR TITLE
Fix dropdown selection

### DIFF
--- a/script.js
+++ b/script.js
@@ -601,8 +601,8 @@ function searchPlayers() {
                     match => `<strong>${match}</strong>`
                 );
                 return `
-                    <div class="dropdown-item ${index === selectedSearchItem ? 'selected' : ''}" 
-                         onclick="selectPlayer('${player}')">
+                    <div class="dropdown-item ${index === selectedSearchItem ? 'selected' : ''}"
+                         onclick="selectPlayerByUsername('${player.username}')">
                         ${highlightedName}
                     </div>`;
             })
@@ -626,6 +626,14 @@ function selectPlayer(player) {
             button.click();
         }
     });
+}
+
+// Helper to select a player when only the username is available
+function selectPlayerByUsername(username) {
+    const player = players.find(p => p.username === username);
+    if (player) {
+        selectPlayer(player);
+    }
 }
 
 
@@ -790,4 +798,14 @@ function addNewPlayer(playerData) {
                 reject(error);
             });
     });
+}
+
+// Export functions for testing in Node environments
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = {
+        addPlayer,
+        saveAttendance,
+        selectPlayerByUsername,
+        selectPlayer,
+    };
 }


### PR DESCRIPTION
## Summary
- fix searchPlayers dropdown to pass username instead of object
- add helper to select a player by username
- export functions for testing

## Testing
- `npm test --silent` *(fails: Player Management / Attendance Management)*

------
https://chatgpt.com/codex/tasks/task_e_683fdbca98e883339fac77d22570c5fa