### PR TITLE
Fix duplicate name check

### DIFF
--- a/script.js
+++ b/script.js
@@ -241,9 +241,15 @@ function addPlayer() {
         .join(' ');
 
     // Check for duplicates (case-insensitive)
-    const nameExists = players.some(player =>
-        player.toLowerCase() === normalizedName.toLowerCase()
-    );
+    const nameExists = players.some(player => {
+        if (typeof player === 'string') {
+            return player.toLowerCase() === normalizedName.toLowerCase();
+        }
+        if (player && player.username) {
+            return player.username.toLowerCase() === normalizedName.toLowerCase();
+        }
+        return false;
+    });
 
     if (nameExists) {
         alert('This player already exists!');
@@ -791,3 +797,5 @@ function addNewPlayer(playerData) {
             });
     });
 }
+
+if (typeof module !== "undefined") { module.exports = { addPlayer, saveAttendance, deleteAttendance, displayPlayers, displayAttendanceHistory, togglePlayerSelection, toggleSelectAll, getSelectedPlayers, showAddPlayerModal, addNewPlayer }; }


### PR DESCRIPTION
## Summary
- fix the duplicate check in `addPlayer`
- export script functions so they can be required

## Testing
- `npm test` *(fails: Player Management › Add player successfully, Cannot add empty player name, Cannot add duplicate player, Attendance Management › Save attendance successfully)*

------
https://chatgpt.com/codex/tasks/task_e_683fdbe268e083339365ee4e26500523