### PR TITLE
Fix player lookup and remove duplicate styles

### DIFF
--- a/script.js
+++ b/script.js
@@ -241,9 +241,10 @@ function addPlayer() {
         .join(' ');
 
     // Check for duplicates (case-insensitive)
-    const nameExists = players.some(player =>
-        player.toLowerCase() === normalizedName.toLowerCase()
-    );
+    const nameExists = players.some(player => {
+        const playerName = typeof player === 'string' ? player : player.username;
+        return (playerName || '').toLowerCase() === normalizedName.toLowerCase();
+    });
 
     if (nameExists) {
         alert('This player already exists!');
@@ -601,8 +602,8 @@ function searchPlayers() {
                     match => `<strong>${match}</strong>`
                 );
                 return `
-                    <div class="dropdown-item ${index === selectedSearchItem ? 'selected' : ''}" 
-                         onclick="selectPlayer('${player}')">
+                    <div class="dropdown-item ${index === selectedSearchItem ? 'selected' : ''}"
+                         onclick="selectPlayer('${player.username}')">
                         ${highlightedName}
                     </div>`;
             })
@@ -615,6 +616,9 @@ function searchPlayers() {
 
 // Fix player selection from dropdown
 function selectPlayer(player) {
+    if (typeof player === 'string') {
+        player = { username: player };
+    }
     const searchInput = document.getElementById('searchInput');
     searchInput.value = player.username;
     document.getElementById('searchDropdown').style.display = 'none';

--- a/styles.css
+++ b/styles.css
@@ -846,34 +846,6 @@ screen and (min-resolution: 192dpi) {
     color: var(--accent-red);
 }
 
-/* Submit button styles */
-.confirm-btn {
-    background-color: #ccc;
-    color: white;
-    padding: 12px 28px;
-    border: none;
-    border-radius: 8px;
-    font-size: 16px;
-    font-weight: 500;
-    transition: all 0.3s ease;
-}
-
-.confirm-btn:disabled {
-    background-color: #ccc;
-    cursor: not-allowed;
-    opacity: 0.7;
-}
-
-.confirm-btn:not(:disabled) {
-    background-color: var(--accent-green);
-    cursor: pointer;
-}
-
-.confirm-btn:not(:disabled):hover {
-    transform: translateY(-1px);
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-}
-
 /* Grid layout for headers and items */
 .list-headers,
 .player-item {


### PR DESCRIPTION
## Summary
- handle both string and object forms when checking for duplicate players
- ensure search dropdown passes username only
- allow `selectPlayer` to accept username strings
- remove duplicate `.confirm-btn` CSS block

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ff9c819b083339ff9045d2b474f4b